### PR TITLE
Cloud Storage: Fix default ACL mode

### DIFF
--- a/kubernetes/deployment.yaml.template
+++ b/kubernetes/deployment.yaml.template
@@ -53,7 +53,7 @@ spec:
           - name: GS_CREDENTIALS
             value: /secrets/cloud-storage/nexus-storage.service-account.json
           - name: GS_DEFAULT_ACL
-            value: public-read
+            value: publicRead
         volumeMounts:
           - name: cloud-storage-credentials
             mountPath: /secrets/cloud-storage


### PR DESCRIPTION
Fix the default cloud storage ACL mode, as it had an invalid
value.

No refs